### PR TITLE
Add OpenChain fallback for selector decoding

### DIFF
--- a/multisend-ui/__tests__/TransactionList.test.tsx
+++ b/multisend-ui/__tests__/TransactionList.test.tsx
@@ -10,7 +10,7 @@ jest.mock('@/utils/decoder', () => {
   const originalModule = jest.requireActual('@/utils/decoder');
   return {
     ...originalModule,
-    tryDecodeFunctionData: jest.fn((data: string) => {
+    tryDecodeFunctionData: jest.fn(async (data: string) => {
       if (data.startsWith('0x095ea7b3')) {
         return {
           name: 'approve(address,uint256)',
@@ -114,24 +114,24 @@ describe('TransactionList', () => {
     expect(screen.getByText('No transactions to display')).toBeInTheDocument();
   });
 
-  it('displays decoded function information', () => {
+  it('displays decoded function information', async () => {
     render(<TransactionList transactions={mockTransactions} />);
     
     // Check that the approve function is decoded correctly
-    expect(screen.getByText('Function: approve(address,uint256)')).toBeInTheDocument();
+    expect(await screen.findByText('Function: approve(address,uint256)')).toBeInTheDocument();
     
     // Check that the injectReward function is decoded correctly
-    expect(screen.getByText('Function: injectReward(uint256,uint256)')).toBeInTheDocument();
+    expect(await screen.findByText('Function: injectReward(uint256,uint256)')).toBeInTheDocument();
     
     // Check for parameter labels (using getAllByText since they appear multiple times)
-    const timestampLabels = screen.getAllByText(/timestamp/i);
+    const timestampLabels = await screen.findAllByText(/timestamp/i);
     expect(timestampLabels.length).toBeGreaterThan(0);
     
-    const amountLabels = screen.getAllByText(/amount/i);
+    const amountLabels = await screen.findAllByText(/amount/i);
     expect(amountLabels.length).toBeGreaterThan(0);
   });
 
-  it('displays error message when function decoding fails', () => {
+  it('displays error message when function decoding fails', async () => {
     // Create a new mock implementation for this test
     const errorMockTransactions: DecodedTransaction[] = [
       {
@@ -144,7 +144,7 @@ describe('TransactionList', () => {
     ];
     
     // Override the mock for this specific test
-    (decoderUtils.tryDecodeFunctionData as jest.Mock).mockReturnValueOnce({
+    (decoderUtils.tryDecodeFunctionData as jest.Mock).mockResolvedValueOnce({
       name: 'injectReward(uint256,uint256)',
       params: {},
       error: 'Failed to decode injectReward function parameters'
@@ -153,6 +153,6 @@ describe('TransactionList', () => {
     render(<TransactionList transactions={errorMockTransactions} />);
     
     // Check that the error message is displayed
-    expect(screen.getByText(/Failed to decode injectReward function parameters/)).toBeInTheDocument();
+    expect(await screen.findByText(/Failed to decode injectReward function parameters/)).toBeInTheDocument();
   });
 }); 

--- a/multisend-ui/app/api/openchain/route.ts
+++ b/multisend-ui/app/api/openchain/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const OPENCHAIN_LOOKUP_URL = 'https://api.openchain.xyz/signature-database/v1/lookup';
+const SELECTOR_REGEX = /^0x[0-9a-fA-F]{8}$/;
+
+export async function GET(request: NextRequest) {
+  const selector = request.nextUrl.searchParams.get('function') ?? request.nextUrl.searchParams.get('selector');
+
+  if (!selector || !SELECTOR_REGEX.test(selector)) {
+    return NextResponse.json({ error: 'Invalid selector' }, { status: 400 });
+  }
+
+  try {
+    const url = new URL(OPENCHAIN_LOOKUP_URL);
+    url.searchParams.set('function', selector.toLowerCase());
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        accept: 'application/json'
+      }
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      return NextResponse.json(
+        {
+          error: 'OpenChain lookup failed',
+          status: response.status,
+          details: body
+        },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    console.error('OpenChain proxy error:', error);
+    return NextResponse.json({ error: 'OpenChain proxy error' }, { status: 502 });
+  }
+}

--- a/multisend-ui/app/page.tsx
+++ b/multisend-ui/app/page.tsx
@@ -16,7 +16,7 @@ export default function Home() {
   const [inputData, setInputData] = useState('');
   const formRef = useRef<HTMLFormElement>(null);
 
-  const handleParse = (data: string) => {
+  const handleParse = async (data: string) => {
     try {
       // First, try to parse as JSON (for backward compatibility)
       try {
@@ -28,7 +28,8 @@ export default function Home() {
           return;
         } else if (parsedData.data) {
           // If the JSON has a 'data' field that contains the multisend data
-          setTransactions(decodeTransactionData(parsedData.data));
+          const decoded = await decodeTransactionData(parsedData.data);
+          setTransactions(decoded);
           return;
         } else if (parsedData.transactions) {
           // If the JSON has a 'transactions' field
@@ -40,15 +41,19 @@ export default function Home() {
       }
       
       // Treat as raw transaction data (multisend or regular function call)
-      setTransactions(decodeTransactionData(data));
+      const decoded = await decodeTransactionData(data);
+      setTransactions(decoded);
     } catch (error) {
       console.error('Error parsing data:', error);
       setTransactions([]);
     }
   };
 
-  const handleImageProcessed = (data: any) => {
+  const handleImageProcessed = async (data: any) => {
     setIsLoading(false);
+    if (data && data._resetLoading) {
+      return;
+    }
     
     // If the data contains the 'data' field, use it
     if (data.data) {
@@ -56,12 +61,12 @@ export default function Home() {
       setInputData(data.data);
       
       // Parse the data
-      handleParse(data.data);
+      await handleParse(data.data);
     } else {
       // Otherwise, stringify the entire JSON and use it
       const jsonString = JSON.stringify(data, null, 2);
       setInputData(jsonString);
-      handleParse(jsonString);
+      await handleParse(jsonString);
     }
   };
 

--- a/multisend-ui/components/ImageUpload.tsx
+++ b/multisend-ui/components/ImageUpload.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 
 interface ImageUploadProps {
-  onImageProcessed: (data: any) => void;
+  onImageProcessed: (data: any) => Promise<void> | void;
   isLoading: boolean;
   setIsLoading?: (loading: boolean) => void;
   buttonText?: string;
@@ -47,7 +47,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
       const data = await response.json();
       
       if (response.ok) {
-        onImageProcessed(data);
+        await onImageProcessed(data);
       } else {
         console.error('Error extracting JSON:', data.error);
       }
@@ -59,7 +59,9 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
         setTimeout(() => {
           // Give the parent component time to process the data
           // before resetting the loading state
-          onImageProcessed({ _resetLoading: true });
+          Promise.resolve(onImageProcessed({ _resetLoading: true })).catch(err => {
+            console.error('Failed to reset loading state after image processing:', err);
+          });
         }, 500);
       }
     }

--- a/multisend-ui/components/TransactionList.tsx
+++ b/multisend-ui/components/TransactionList.tsx
@@ -12,16 +12,14 @@ const TransactionList: React.FC<TransactionListProps> = ({ transactions }) => {
   useEffect(() => {
     let cancelled = false;
     async function decodeAll() {
-      try {
-        const results = await Promise.all(transactions.map(tx => tryDecodeFunctionData(tx.data)));
-        if (!cancelled) {
-          setDecodedFunctions(results);
-        }
-      } catch (error) {
-        if (!cancelled) {
-          console.error('Failed to decode transaction functions:', error);
-          setDecodedFunctions(transactions.map(() => null));
-        }
+      const results = await Promise.allSettled(
+        transactions.map(tx => tryDecodeFunctionData(tx.data))
+      );
+      if (!cancelled) {
+        const decodedResults = results.map(result =>
+          result.status === 'fulfilled' ? result.value : null
+        );
+        setDecodedFunctions(decodedResults);
       }
     }
     decodeAll();

--- a/multisend-ui/components/checksums/ResultDisplay.tsx
+++ b/multisend-ui/components/checksums/ResultDisplay.tsx
@@ -17,6 +17,8 @@ export default function ResultDisplay({ result }: ResultDisplayProps) {
     );
   }
 
+  const decodedData = result.transaction?.data_decoded;
+
   return (
     <div className="space-y-6">
       {/* Network Info */}
@@ -55,27 +57,27 @@ export default function ResultDisplay({ result }: ResultDisplayProps) {
                 {result.transaction.data}
               </div>
             </div>
-            {result.transaction.data_decoded && (
+            {decodedData && (
               <div className="grid grid-cols-1 gap-1">
                 <div className="text-gray-500">Data Decoded:</div>
                 <div className="font-mono">
-                  <div>Method: {result.transaction.data_decoded.method}</div>
-                  {result.transaction.data_decoded.signature && (
-                    <div className="text-xs text-gray-500">Signature: {result.transaction.data_decoded.signature}</div>
+                  <div>Method: {decodedData.method}</div>
+                  {decodedData.signature && (
+                    <div className="text-xs text-gray-500">Signature: {decodedData.signature}</div>
                   )}
-                  {result.transaction.data_decoded.source && (
-                    <div className="text-xs text-gray-500">Source: {result.transaction.data_decoded.source}</div>
+                  {decodedData.source && (
+                    <div className="text-xs text-gray-500">Source: {decodedData.source}</div>
                   )}
-                  {result.transaction.data_decoded.candidates && result.transaction.data_decoded.candidates.length > 1 && (
+                  {decodedData.candidates && decodedData.candidates.length > 1 && (
                     <div className="text-xs text-blue-600">
-                      Other matches: {result.transaction.data_decoded.candidates.filter(candidate => candidate !== result.transaction.data_decoded.method).join(', ')}
+                      Other matches: {decodedData.candidates.filter(candidate => candidate !== decodedData.method).join(', ')}
                     </div>
                   )}
-                  {result.transaction.data_decoded.parameters && result.transaction.data_decoded.parameters.length > 0 && (
+                  {decodedData.parameters && decodedData.parameters.length > 0 && (
                     <div className="mt-2">
                       <div className="text-gray-500">Parameters:</div>
                       <pre className="bg-gray-100 p-2 rounded text-xs overflow-x-auto">
-                        {JSON.stringify(result.transaction.data_decoded.parameters, null, 2)}
+                        {JSON.stringify(decodedData.parameters, null, 2)}
                       </pre>
                     </div>
                   )}

--- a/multisend-ui/components/checksums/ResultDisplay.tsx
+++ b/multisend-ui/components/checksums/ResultDisplay.tsx
@@ -59,7 +59,18 @@ export default function ResultDisplay({ result }: ResultDisplayProps) {
               <div className="grid grid-cols-1 gap-1">
                 <div className="text-gray-500">Data Decoded:</div>
                 <div className="font-mono">
-                  Method: {result.transaction.data_decoded.method}
+                  <div>Method: {result.transaction.data_decoded.method}</div>
+                  {result.transaction.data_decoded.signature && (
+                    <div className="text-xs text-gray-500">Signature: {result.transaction.data_decoded.signature}</div>
+                  )}
+                  {result.transaction.data_decoded.source && (
+                    <div className="text-xs text-gray-500">Source: {result.transaction.data_decoded.source}</div>
+                  )}
+                  {result.transaction.data_decoded.candidates && result.transaction.data_decoded.candidates.length > 1 && (
+                    <div className="text-xs text-blue-600">
+                      Other matches: {result.transaction.data_decoded.candidates.filter(candidate => candidate !== result.transaction.data_decoded.method).join(', ')}
+                    </div>
+                  )}
                   {result.transaction.data_decoded.parameters && result.transaction.data_decoded.parameters.length > 0 && (
                     <div className="mt-2">
                       <div className="text-gray-500">Parameters:</div>

--- a/multisend-ui/components/checksums/TransactionForm.tsx
+++ b/multisend-ui/components/checksums/TransactionForm.tsx
@@ -9,6 +9,7 @@ import {
   tryDecodeFunctionData, 
   decodeTransactionData, 
   DecodedTransaction,
+  DecodedFunctionData,
   parseSignTypedDataJson,
   decodeMultiSendTransactions,
   normalizeHexString
@@ -18,11 +19,7 @@ import {
  * Represents a transaction with decoded data
  */
 interface DecodedTransactionWithFunction extends DecodedTransaction {
-  decodedFunction?: {
-    name: string;
-    params: Record<string, string>;
-    error?: string;
-  } | null;
+  decodedFunction?: DecodedFunctionData | null;
   nestedTransactions?: DecodedTransactionWithFunction[] | null;
 }
 
@@ -31,35 +28,35 @@ interface DecodedTransactionWithFunction extends DecodedTransaction {
  * @param transactions The transactions to decode
  * @returns Transactions with decoded data
  */
-function decodeTransactionsRecursively(transactions: DecodedTransaction[]): DecodedTransactionWithFunction[] {
-  return transactions.map(tx => {
+async function decodeTransactionsRecursively(transactions: DecodedTransaction[]): Promise<DecodedTransactionWithFunction[]> {
+  return Promise.all(transactions.map(async tx => {
     const result: DecodedTransactionWithFunction = {
       ...tx,
       decodedFunction: null,
       nestedTransactions: null
     };
-    
-    // Skip empty data
+
     if (!tx.data || tx.data === '0x') {
       return result;
     }
-    
-    // Try to decode as a function call
-    result.decodedFunction = tryDecodeFunctionData(normalizeHexString(tx.data));
-    
-    // Try to decode as a multisend transaction
+
     try {
-      const nestedTxs = decodeTransactionData(normalizeHexString(tx.data));
+      result.decodedFunction = await tryDecodeFunctionData(normalizeHexString(tx.data));
+    } catch (error) {
+      console.error('Failed to decode function data for transaction:', error);
+    }
+
+    try {
+      const nestedTxs = await decodeTransactionData(normalizeHexString(tx.data));
       if (nestedTxs.length > 1) {
-        // It's a nested multisend transaction
-        result.nestedTransactions = decodeTransactionsRecursively(nestedTxs);
+        result.nestedTransactions = await decodeTransactionsRecursively(nestedTxs);
       }
     } catch (error) {
-      // Not a multisend transaction, which is fine
+      // Not a multisend transaction or failed to decode; continue without nested data
     }
-    
+
     return result;
-  });
+  }));
 }
 
 interface TransactionFormProps {
@@ -82,7 +79,7 @@ export default function TransactionForm({
   initialRecipient
 }: TransactionFormProps) {
   const [imageLoading, setImageLoading] = useState(false);
-  const [decodedData, setDecodedData] = useState<{ name: string; params: Record<string, string>; error?: string } | null>(null);
+  const [decodedData, setDecodedData] = useState<DecodedFunctionData | null>(null);
   const [decodedTransactions, setDecodedTransactions] = useState<DecodedTransactionWithFunction[] | null>(null);
   const [jsonInput, setJsonInput] = useState<string>('');
   const [jsonError, setJsonError] = useState<string | null>(null);
@@ -302,90 +299,81 @@ export default function TransactionForm({
 
   // Watch for changes to the data field
   React.useEffect(() => {
-    const subscription = form.watch((value, { name }) => {
-      if (name === "data") {
-        const currentData = value.data as string;
-        setDecodedData(null); // Reset states
-        setDecodedTransactions(null);
+    let cancelled = false;
 
-        if (currentData && currentData !== '0x') {
-          try {
-            const normalizedCurrentData = normalizeHexString(currentData);
-            
-            // 1. Check if the currentData is a call to multiSend(bytes)
-            const topLevelDecoded = tryDecodeFunctionData(normalizedCurrentData);
-            if (topLevelDecoded && topLevelDecoded.name === 'multiSend(bytes)' && topLevelDecoded.params.transactions) {
-              const innerTransactionsData = '0x' + topLevelDecoded.params.transactions;
-              const decodedInnerTxs = decodeMultiSendTransactions(innerTransactionsData);
-              setDecodedTransactions(decodeTransactionsRecursively(decodedInnerTxs));
-              setDecodedData(topLevelDecoded); // Show the outer multiSend(bytes) call
-            } else {
-              // 2. If not multiSend(bytes), try to decode it as a bundle of transactions OR a single transaction
-              const transactions = decodeTransactionData(normalizedCurrentData);
-              if (transactions.length > 1) {
-                setDecodedTransactions(decodeTransactionsRecursively(transactions));
-                setDecodedData(null); // This is a bundle, not a single call
-              } else if (transactions.length === 1) {
-                // It's a single transaction, try to decode its function data
-                setDecodedData(tryDecodeFunctionData(normalizeHexString(transactions[0].data)));
-                setDecodedTransactions(null);
-              } else {
-                // Fallback: Still try to decode as a single function if no transactions were found by decodeTransactionData
-                // This might happen if data is very short or not a bundle.
-                setDecodedData(tryDecodeFunctionData(normalizedCurrentData));
-                setDecodedTransactions(null);
-              }
-            }
-          } catch (error) {
-            console.error("Error decoding data in watcher (in form):", error);
-            setDecodedData({ name: "Error decoding data", params: {}, error: (error instanceof Error ? error.message : String(error)) });
-            setDecodedTransactions(null);
-          }
-        }
+    const applyDecodedState = async (rawData: string) => {
+      if (cancelled) return;
+      setDecodedData(null);
+      setDecodedTransactions(null);
+
+      if (!rawData || rawData === '0x') {
+        return;
       }
-    });
 
-    // Initial decode of current data (this logic should be consistent with the watcher)
-    const initialData = form.getValues("data");
-    if (initialData && initialData !== '0x') {
       try {
-        const normalizedInitialData = normalizeHexString(initialData);
-        const topLevelDecoded = tryDecodeFunctionData(normalizedInitialData);
+        const normalizedData = normalizeHexString(rawData);
+        const topLevelDecoded = await tryDecodeFunctionData(normalizedData);
+
+        if (cancelled) return;
 
         if (topLevelDecoded && topLevelDecoded.name === 'multiSend(bytes)' && topLevelDecoded.params.transactions) {
           const innerTransactionsData = '0x' + topLevelDecoded.params.transactions;
           const decodedInnerTxs = decodeMultiSendTransactions(innerTransactionsData);
-          setDecodedTransactions(decodeTransactionsRecursively(decodedInnerTxs));
-          setDecodedData(topLevelDecoded);
-        } else {
-          const transactions = decodeTransactionData(normalizedInitialData);
-          if (transactions.length > 1) {
-            setDecodedTransactions(decodeTransactionsRecursively(transactions));
+          const nested = await decodeTransactionsRecursively(decodedInnerTxs);
+          if (!cancelled) {
+            setDecodedTransactions(nested);
+            setDecodedData(topLevelDecoded);
+          }
+          return;
+        }
+
+        const transactions = await decodeTransactionData(normalizedData);
+        if (cancelled) return;
+
+        if (transactions.length > 1) {
+          const nested = await decodeTransactionsRecursively(transactions);
+          if (!cancelled) {
+            setDecodedTransactions(nested);
             setDecodedData(null);
-          } else if (transactions.length === 1) {
-            setDecodedData(tryDecodeFunctionData(normalizeHexString(transactions[0].data)));
+          }
+        } else if (transactions.length === 1) {
+          const innerDecoded = await tryDecodeFunctionData(normalizeHexString(transactions[0].data));
+          if (!cancelled) {
+            setDecodedData(innerDecoded);
             setDecodedTransactions(null);
-          } else {
-            setDecodedData(tryDecodeFunctionData(normalizedInitialData));
+          }
+        } else {
+          const fallbackDecoded = await tryDecodeFunctionData(normalizedData);
+          if (!cancelled) {
+            setDecodedData(fallbackDecoded);
             setDecodedTransactions(null);
           }
         }
       } catch (error) {
-        console.error("Error decoding initial data (in form):", error);
-        setDecodedData({ name: "Error decoding initial data", params: {}, error: (error instanceof Error ? error.message : String(error)) });
-        setDecodedTransactions(null);
+        if (!cancelled) {
+          console.error('Error decoding data in watcher (in form):', error);
+          setDecodedData({ name: 'Error decoding data', params: {}, error: error instanceof Error ? error.message : String(error) });
+          setDecodedTransactions(null);
+        }
       }
-    } else {
-      setDecodedData(null);
-      setDecodedTransactions(null);
-    }
-    
+    };
+
+    const subscription = form.watch((value, { name }) => {
+      if (name === 'data') {
+        void applyDecodedState(value.data as string);
+      }
+    });
+
+    const initialData = form.getValues('data');
+    void applyDecodedState(initialData as string);
+
     return () => {
+      cancelled = true;
       if (subscription && typeof subscription.unsubscribe === 'function') {
         subscription.unsubscribe();
       }
     };
-  }, [form]); // form.watch should be stable. form.getValues("data") could be a dependency if needed.
+  }, [form]);
 
   const handleCalculationSubmit = async (e?: React.BaseSyntheticEvent) => {
     e?.preventDefault();
@@ -455,7 +443,7 @@ export default function TransactionForm({
     setJsonInput(e.target.value);
   };
 
-  const handleParseJson = () => {
+  const handleParseJson = async () => {
     if (!jsonInput.trim()) {
       setJsonError('Please enter JSON data');
       return;
@@ -463,7 +451,7 @@ export default function TransactionForm({
 
     try {
       // Parse the JSON content
-      const parsedData = parseSignTypedDataJson(jsonInput);
+      const parsedData = await parseSignTypedDataJson(jsonInput);
       
       if (!parsedData) {
         setJsonError('Failed to parse JSON content. Make sure it contains valid transaction data.');
@@ -484,7 +472,8 @@ export default function TransactionForm({
       
       // Update decoded data state
       if (parsedData.decodedTransactions && parsedData.decodedTransactions.length > 0) {
-        setDecodedTransactions(decodeTransactionsRecursively(parsedData.decodedTransactions));
+        const nested = await decodeTransactionsRecursively(parsedData.decodedTransactions);
+        setDecodedTransactions(nested);
         setDecodedData(parsedData.decodedData); // Keep the function data for reference
       } else if (parsedData.decodedData) {
         setDecodedData(parsedData.decodedData);
@@ -517,12 +506,17 @@ export default function TransactionForm({
   /**
    * Renders a decoded function
    */
-  const renderDecodedFunction = (decodedFunction: { name: string; params: Record<string, string>; error?: string } | null) => {
+  const renderDecodedFunction = (decodedFunction: DecodedFunctionData | null) => {
     if (!decodedFunction) return null;
     
     return (
       <div className="mt-2 pl-4 border-l-2 border-gray-200">
         <h6 className="font-medium text-gray-700">Function: {decodedFunction.name}</h6>
+        {decodedFunction.source === 'openchain' && decodedFunction.candidates && decodedFunction.candidates.length > 1 && (
+          <p className="text-xs text-blue-600 mt-1">
+            Possible matches: {decodedFunction.candidates.filter(candidate => candidate !== decodedFunction.name).join(', ')}
+          </p>
+        )}
         
         {decodedFunction.error ? (
           <p className="text-red-500 mt-1 text-xs">{decodedFunction.error}</p>

--- a/multisend-ui/test-complex-multisend.ts
+++ b/multisend-ui/test-complex-multisend.ts
@@ -3,58 +3,60 @@ import { tryDecodeFunctionData, decodeMultiSendTransactions } from './utils/deco
 // The complex multiSend function data with offset and length
 const complexMultiSendData = '0x8d80ff0a0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000013200ef4461891dfb3ac8572ccf7c794664a8dd92794500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000044095ea7b3000000000000000000000000f368f535e329c6d08dff0d4b2da961c4e7f3fcaf000000000000000000000000000000000000000000000593824f86a5fe30de1200f368f535e329c6d08dff0d4b2da961c4e7f3fcaf00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000044097cd2320000000000000000000000000000000000000000000000000000000067c8e580000000000000000000000000000000000000000000000593824f86a5fe30de120000000000000000000000000000';
 
-console.log('Testing decoding of complex multiSend function data with offset and length:');
-console.log('-------------------------------------------------------------------');
+async function main() {
+  console.log('Testing decoding of complex multiSend function data with offset and length:');
+  console.log('-------------------------------------------------------------------');
 
-// Try to decode the function data
-const decodedFunction = tryDecodeFunctionData(complexMultiSendData);
+  const decodedFunction = await tryDecodeFunctionData(complexMultiSendData);
 
-if (decodedFunction) {
-  console.log('Function name:', decodedFunction.name);
-  console.log('Parameters:');
-  
-  if ('transactions' in decodedFunction.params) {
-    console.log('  transactions length:', decodedFunction.params.transactions.length);
-    
-    // Try to decode the transactions
-    try {
-      const transactionsData = '0x' + decodedFunction.params.transactions;
-      const decodedTransactions = decodeMultiSendTransactions(transactionsData);
-      
-      console.log('\nDecoded transactions count:', decodedTransactions.length);
-      
-      // Log details of each transaction
-      decodedTransactions.forEach((tx, index) => {
-        console.log(`\nTransaction #${index + 1}:`);
-        console.log('  Operation:', tx.operation === 0 ? 'Call' : 'DelegateCall');
-        console.log('  To:', tx.to);
-        console.log('  Value:', tx.value);
-        console.log('  Data Length:', tx.dataLength, 'bytes');
-        console.log('  Data:', tx.data);
-        
-        // Try to decode the function data of the transaction
-        const txFunction = tryDecodeFunctionData(tx.data);
-        if (txFunction) {
-          console.log('\n  Decoded Function:');
-          console.log('    Name:', txFunction.name);
-          console.log('    Parameters:');
-          Object.entries(txFunction.params).forEach(([key, value]) => {
-            console.log(`      ${key}: ${value}`);
-          });
-        } else {
-          console.log('\n  Could not decode function data');
+  if (decodedFunction) {
+    console.log('Function name:', decodedFunction.name);
+    console.log('Parameters:');
+
+    if ('transactions' in decodedFunction.params) {
+      console.log('  transactions length:', decodedFunction.params.transactions.length);
+
+      try {
+        const transactionsData = '0x' + decodedFunction.params.transactions;
+        const decodedTransactions = decodeMultiSendTransactions(transactionsData);
+
+        console.log('\nDecoded transactions count:', decodedTransactions.length);
+
+        for (const [index, tx] of decodedTransactions.entries()) {
+          console.log(`\nTransaction #${index + 1}:`);
+          console.log('  Operation:', tx.operation === 0 ? 'Call' : 'DelegateCall');
+          console.log('  To:', tx.to);
+          console.log('  Value:', tx.value);
+          console.log('  Data Length:', tx.dataLength, 'bytes');
+          console.log('  Data:', tx.data);
+
+          const txFunction = await tryDecodeFunctionData(tx.data);
+          if (txFunction) {
+            console.log('\n  Decoded Function:');
+            console.log('    Name:', txFunction.name);
+            console.log('    Parameters:');
+            Object.entries(txFunction.params).forEach(([key, value]) => {
+              console.log(`      ${key}: ${value}`);
+            });
+          } else {
+            console.log('\n  Could not decode function data');
+          }
         }
-      });
-    } catch (error) {
-      console.error('Error decoding transactions:', error);
+      } catch (error) {
+        console.error('Error decoding transactions:', error);
+      }
+    } else {
+      console.log('  No transactions parameter found');
+    }
+
+    if (decodedFunction.error) {
+      console.log('Error:', decodedFunction.error);
     }
   } else {
-    console.log('  No transactions parameter found');
+    console.log('Could not decode function data');
   }
-  
-  if (decodedFunction.error) {
-    console.log('Error:', decodedFunction.error);
-  }
-} else {
-  console.log('Could not decode function data');
-} 
+}
+
+void main().catch(error => {
+  console.error('Failed to run complex multiSend decoding script:', error);
+});

--- a/multisend-ui/test-user-multisend.ts
+++ b/multisend-ui/test-user-multisend.ts
@@ -3,59 +3,61 @@ import { tryDecodeFunctionData, decodeMultiSendTransactions } from './utils/deco
 // The multiSend payload from the user's query
 const userMultiSendData = '0x8d80ff0a0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000013200ef4461891dfb3ac8572ccf7c794664a8dd92794500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000044095ea7b3000000000000000000000000f368f535e329c6d08dff0d4b2da961c4e7f3fcaf000000000000000000000000000000000000000000000593824f86a5fe30de1200f368f535e329c6d08dff0d4b2da961c4e7f3fcaf00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000044097cd2320000000000000000000000000000000000000000000000000000000067c8e580000000000000000000000000000000000000000000000593824f86a5fe30de120000000000000000000000000000';
 
-console.log('Testing decoding of user\'s multiSend payload:');
-console.log('-------------------------------------------------------------------');
+async function main() {
+  console.log('Testing decoding of user\'s multiSend payload:');
+  console.log('-------------------------------------------------------------------');
 
-// Try to decode the function data
-const decodedFunction = tryDecodeFunctionData(userMultiSendData);
+  const decodedFunction = await tryDecodeFunctionData(userMultiSendData);
 
-if (decodedFunction) {
-  console.log('Function name:', decodedFunction.name);
-  console.log('Parameters:');
-  
-  if ('transactions' in decodedFunction.params) {
-    console.log('  transactions length:', decodedFunction.params.transactions.length);
-    console.log('  decodedTransactionsCount:', decodedFunction.params.decodedTransactionsCount);
-    
-    // Try to decode the transactions
-    try {
-      const transactionsData = '0x' + decodedFunction.params.transactions;
-      const decodedTransactions = decodeMultiSendTransactions(transactionsData);
-      
-      console.log('\nDecoded transactions count:', decodedTransactions.length);
-      
-      // Log details of each transaction
-      decodedTransactions.forEach((tx, index) => {
-        console.log(`\nTransaction #${index + 1}:`);
-        console.log('  Operation:', tx.operation === 0 ? 'Call' : 'DelegateCall');
-        console.log('  To:', tx.to);
-        console.log('  Value:', tx.value);
-        console.log('  Data Length:', tx.dataLength, 'bytes');
-        console.log('  Data:', tx.data);
-        
-        // Try to decode the function data of the transaction
-        const txFunction = tryDecodeFunctionData(tx.data);
-        if (txFunction) {
-          console.log('\n  Decoded Function:');
-          console.log('    Name:', txFunction.name);
-          console.log('    Parameters:');
-          Object.entries(txFunction.params).forEach(([key, value]) => {
-            console.log(`      ${key}: ${value}`);
-          });
-        } else {
-          console.log('\n  Could not decode function data');
+  if (decodedFunction) {
+    console.log('Function name:', decodedFunction.name);
+    console.log('Parameters:');
+
+    if ('transactions' in decodedFunction.params) {
+      console.log('  transactions length:', decodedFunction.params.transactions.length);
+      console.log('  decodedTransactionsCount:', decodedFunction.params.decodedTransactionsCount);
+
+      try {
+        const transactionsData = '0x' + decodedFunction.params.transactions;
+        const decodedTransactions = decodeMultiSendTransactions(transactionsData);
+
+        console.log('\nDecoded transactions count:', decodedTransactions.length);
+
+        for (const [index, tx] of decodedTransactions.entries()) {
+          console.log(`\nTransaction #${index + 1}:`);
+          console.log('  Operation:', tx.operation === 0 ? 'Call' : 'DelegateCall');
+          console.log('  To:', tx.to);
+          console.log('  Value:', tx.value);
+          console.log('  Data Length:', tx.dataLength, 'bytes');
+          console.log('  Data:', tx.data);
+
+          const txFunction = await tryDecodeFunctionData(tx.data);
+          if (txFunction) {
+            console.log('\n  Decoded Function:');
+            console.log('    Name:', txFunction.name);
+            console.log('    Parameters:');
+            Object.entries(txFunction.params).forEach(([key, value]) => {
+              console.log(`      ${key}: ${value}`);
+            });
+          } else {
+            console.log('\n  Could not decode function data');
+          }
         }
-      });
-    } catch (error) {
-      console.error('Error decoding transactions:', error);
+      } catch (error) {
+        console.error('Error decoding transactions:', error);
+      }
+    } else {
+      console.log('  No transactions parameter found');
+    }
+
+    if (decodedFunction.error) {
+      console.log('Error:', decodedFunction.error);
     }
   } else {
-    console.log('  No transactions parameter found');
+    console.log('Could not decode function data');
   }
-  
-  if (decodedFunction.error) {
-    console.log('Error:', decodedFunction.error);
-  }
-} else {
-  console.log('Could not decode function data');
-} 
+}
+
+void main().catch(error => {
+  console.error('Failed to run multiSend decoding script:', error);
+});

--- a/multisend-ui/types/checksums.ts
+++ b/multisend-ui/types/checksums.ts
@@ -32,7 +32,9 @@ export interface CalculationResult {
     data_decoded?: {
       method: string;
       signature?: string;
-      parameters: any[];
+      source?: string;
+      candidates?: string[];
+      parameters: { name: string; type?: string; value: string }[];
     };
     exec_transaction?: {
       encoded: string;

--- a/multisend-ui/utils/checksums/use-transaction-calculation.ts
+++ b/multisend-ui/utils/checksums/use-transaction-calculation.ts
@@ -5,7 +5,6 @@ import { NETWORKS } from "./constants";
 import { calculateHashes } from "./safeHashesCalculator";
 import { fetchTransactionDataFromApi } from "./api";
 import { FormData, CalculationResult, TransactionParams } from "@/types/checksums";
-import { decodeTransactionData } from "@/utils/decoder";
 import { parseSafeAddressInput } from "./safeAddressParser";
 
 // Helper function to find network configuration based on various inputs

--- a/multisend-ui/utils/decoder.test.ts
+++ b/multisend-ui/utils/decoder.test.ts
@@ -12,8 +12,8 @@ describe('Decoder Utils', () => {
     const multiSendData = '0x8d80ff0a0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000013200ef4461891dfb3ac8572ccf7c794664a8dd92794500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000044095ea7b3000000000000000000000000f368f535e329c6d08dff0d4b2da961c4e7f3fcaf00000000000000000000000000000000000000000000197faa4d1ae5fd78e25800f368f535e329c6d08dff0d4b2da961c4e7f3fcaf00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000044097cd23200000000000000000000000000000000000000000000000000000000681bf40000000000000000000000000000000000000000000000197faa4d1ae5fd78e2580000000000000000000000000000';
     const expectedTransactionsData = '00ef4461891dfb3ac8572ccf7c794664a8dd92794500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000044095ea7b3000000000000000000000000f368f535e329c6d08dff0d4b2da961c4e7f3fcaf00000000000000000000000000000000000000000000197faa4d1ae5fd78e25800f368f535e329c6d08dff0d4b2da961c4e7f3fcaf00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000044097cd23200000000000000000000000000000000000000000000000000000000681bf40000000000000000000000000000000000000000000000197faa4d1ae5fd78e258';
 
-    it('should correctly identify multiSend function and extract transactions data', () => {
-      const decoded = tryDecodeFunctionData(multiSendData);
+    it('should correctly identify multiSend function and extract transactions data', async () => {
+      const decoded = await tryDecodeFunctionData(multiSendData);
       
       // Log values for debugging
       console.log("Expected transactions data:", expectedTransactionsData);
@@ -42,7 +42,7 @@ describe('Decoder Utils', () => {
         expect(decodedTransactions).toHaveLength(2);
       });
 
-      it('should decode the first transaction (approve) correctly', () => {
+      it('should decode the first transaction (approve) correctly', async () => {
         const tx1 = decodedTransactions[0];
         expect(tx1.operation).toBe(0); // Call
         expect(tx1.to).toBe('0xef4461891dfb3ac8572ccf7c794664a8dd927945');
@@ -51,14 +51,14 @@ describe('Decoder Utils', () => {
         expect(tx1.data).toBe('0x095ea7b3000000000000000000000000f368f535e329c6d08dff0d4b2da961c4e7f3fcaf00000000000000000000000000000000000000000000197faa4d1ae5fd78e258');
 
         // Optionally decode the inner transaction data
-        const innerDecoded1 = tryDecodeFunctionData(tx1.data);
+        const innerDecoded1 = await tryDecodeFunctionData(tx1.data);
         expect(innerDecoded1).not.toBeNull();
         expect(innerDecoded1?.name).toBe('approve(address,uint256)');
         expect(innerDecoded1?.params.spender).toBe('0xf368f535e329c6d08dff0d4b2da961c4e7f3fcaf');
         expect(innerDecoded1?.params.amount).toBe('120414170063237000258136'); // Matches the large number provided
       });
 
-      it('should decode the second transaction (injectReward) correctly', () => {
+      it('should decode the second transaction (injectReward) correctly', async () => {
         const tx2 = decodedTransactions[1];
         expect(tx2.operation).toBe(0); // Call
         expect(tx2.to).toBe('0xf368f535e329c6d08dff0d4b2da961c4e7f3fcaf');
@@ -67,7 +67,7 @@ describe('Decoder Utils', () => {
         expect(tx2.data).toBe('0x097cd23200000000000000000000000000000000000000000000000000000000681bf40000000000000000000000000000000000000000000000197faa4d1ae5fd78e258');
 
         // Optionally decode the inner transaction data
-        const innerDecoded2 = tryDecodeFunctionData(tx2.data);
+        const innerDecoded2 = await tryDecodeFunctionData(tx2.data);
         expect(innerDecoded2).not.toBeNull();
         expect(innerDecoded2?.name).toBe('injectReward(uint256,uint256)');
         // Use formatLargeNumber for comparison as the decoder uses it
@@ -78,11 +78,11 @@ describe('Decoder Utils', () => {
   });
 
   describe('Wormhole function signatures', () => {
-    it('should decode setPeer function correctly', () => {
+    it('should decode setPeer function correctly', async () => {
       // setPeer(uint256,bytes32,uint8,uint256) with peerChainId=30, peerContract=0x164...b, decimals=18, inboundLimit=184467440737095516150000000000
       const setPeerData = '0x7c918634000000000000000000000000000000000000000000000000000000000000001e000000000000000000000000164be303480f542336be0bbe0432a13b85e6fd1b000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000002540be3fffffffffdabf41c00';
 
-      const decoded = tryDecodeFunctionData(setPeerData);
+      const decoded = await tryDecodeFunctionData(setPeerData);
 
       expect(decoded).not.toBeNull();
       expect(decoded?.name).toBe('setPeer(uint256,bytes32,uint8,uint256)');
@@ -92,11 +92,11 @@ describe('Decoder Utils', () => {
       expect(decoded?.params.inboundLimit).toContain('184467440737095516150000000000');
     });
 
-    it('should decode setWormholePeer function correctly', () => {
+    it('should decode setWormholePeer function correctly', async () => {
       // setWormholePeer(uint256,bytes32) with peerChainId=30, peerContract=0x3cb...68
       const setWormholePeerData = '0x7ab56403000000000000000000000000000000000000000000000000000000000000001e0000000000000000000000003cb1d3a449a868dd8bf8f8928408836543fe2a68';
 
-      const decoded = tryDecodeFunctionData(setWormholePeerData);
+      const decoded = await tryDecodeFunctionData(setWormholePeerData);
 
       expect(decoded).not.toBeNull();
       expect(decoded?.name).toBe('setWormholePeer(uint256,bytes32)');
@@ -104,11 +104,11 @@ describe('Decoder Utils', () => {
       expect(decoded?.params.peerContract).toBe('0x3cb1d3a449a868dd8bf8f8928408836543fe2a68');
     });
 
-    it('should decode setIsWormholeEvmChain function correctly', () => {
+    it('should decode setIsWormholeEvmChain function correctly', async () => {
       // setIsWormholeEvmChain(uint256,bool) with chainId=30, isEvm=true
       const setIsWormholeEvmChainData = '0x96dddc63000000000000000000000000000000000000000000000000000000000000001e0000000000000000000000000000000000000000000000000000000000000001';
 
-      const decoded = tryDecodeFunctionData(setIsWormholeEvmChainData);
+      const decoded = await tryDecodeFunctionData(setIsWormholeEvmChainData);
 
       expect(decoded).not.toBeNull();
       expect(decoded?.name).toBe('setIsWormholeEvmChain(uint256,bool)');
@@ -116,11 +116,11 @@ describe('Decoder Utils', () => {
       expect(decoded?.params.isEvm).toBe('true');
     });
 
-    it('should decode setIsWormholeRelayingEnabled function correctly', () => {
+    it('should decode setIsWormholeRelayingEnabled function correctly', async () => {
       // setIsWormholeRelayingEnabled(uint256,bool) with chainId=30, isEnabled=true
       const setIsWormholeRelayingEnabledData = '0x657b3b2f000000000000000000000000000000000000000000000000000000000000001e0000000000000000000000000000000000000000000000000000000000000001';
 
-      const decoded = tryDecodeFunctionData(setIsWormholeRelayingEnabledData);
+      const decoded = await tryDecodeFunctionData(setIsWormholeRelayingEnabledData);
 
       expect(decoded).not.toBeNull();
       expect(decoded?.name).toBe('setIsWormholeRelayingEnabled(uint256,bool)');

--- a/multisend-ui/utils/decoder.ts
+++ b/multisend-ui/utils/decoder.ts
@@ -16,7 +16,12 @@ const openChainResolvedCache = new Map<string, string[]>();
 async function fetchOpenChainFunctionSignatures(selector: string): Promise<string[]> {
   const normalized = selector.toLowerCase();
   if (openChainResolvedCache.has(normalized)) {
-    return openChainResolvedCache.get(normalized) as string[];
+    const cached = openChainResolvedCache.get(normalized);
+    if (cached !== undefined) {
+      return cached;
+    }
+    // Unexpected, but keep behavior predictable.
+    return [];
   }
 
   if (!openChainSignatureCache.has(normalized)) {
@@ -48,7 +53,12 @@ async function fetchOpenChainFunctionSignatures(selector: string): Promise<strin
     openChainSignatureCache.set(normalized, lookupPromise);
   }
 
-  return openChainSignatureCache.get(normalized) as Promise<string[]>;
+  const pending = openChainSignatureCache.get(normalized);
+  if (!pending) {
+    // Shouldn't happen because we just guarded above; treat as cache miss.
+    return [];
+  }
+  return pending;
 }
 
 function formatDecodedValue(value: unknown): string {


### PR DESCRIPTION
## Summary

- add a Next.js `/api/openchain` proxy so both server and browser decoding flow through our API, keeping response format stable and keys private
- harden the decoder to always use the proxy, accept multiple signature fields, deduplicate candidates, and expose cache controls for tests
- surface decoded method metadata (source, candidates, params) inside the checksums workflow and UI so hash results no longer show "Unknown"

## Details

- `multisend-ui/app/api/openchain/route.ts`: validates selectors, forwards to OpenChain, and normalizes error handling for downstream consumers
- `multisend-ui/utils/decoder.ts`: builds proxy URLs for client/server, parses varied signature payloads, dedupes results, and adds a testing hook to clear caches
- `multisend-ui/utils/checksums/use-transaction-calculation.ts`: reuses fetched transactions, auto-decodes payloads via the proxy-backed helper, and reports metadata with hashed results
- `multisend-ui/components/checksums/ResultDisplay.tsx`, `multisend-ui/types/checksums.ts`: display method/signature/source/candidate details alongside hash outputs
- `multisend-ui/utils/decoder.test.ts`: resets caches per test and verifies proxy URL usage plus decoding of selectors like `0xfca3b5aa`

## Testing

- `cd multisend-ui && pnpm test`
