### PR TITLE
Fix: Properly decode and display nested multiSend transactions on
  checksums page

### DIFF
--- a/multisend-ui/__tests__/checksums/ResultDisplay.test.tsx
+++ b/multisend-ui/__tests__/checksums/ResultDisplay.test.tsx
@@ -310,13 +310,15 @@ describe('ResultDisplay', () => {
     });
 
     it('displays all 6 nested transactions from the real example', async () => {
+      const HEX_PARAM_LENGTH = 64; // Ethereum parameter padding length in hex characters
+
       // Create 6 mock transactions matching the real data
       const sixTransactions = Array.from({ length: 6 }, (_, i) => ({
         operation: 0,
         to: '0x398a2749487b2a91f2f543c01f7afd19aee4b6b0',
         value: '0',
         dataLength: 68,
-        data: `0x0d582f13${i.toString().padStart(64, '0')}${(i + 2).toString().padStart(64, '0')}`
+        data: `0x0d582f13${i.toString().padStart(HEX_PARAM_LENGTH, '0')}${(i + 2).toString().padStart(HEX_PARAM_LENGTH, '0')}`
       }));
 
       (decodeMultiSendTransactions as jest.Mock).mockReturnValue(sixTransactions);

--- a/multisend-ui/__tests__/checksums/ResultDisplay.test.tsx
+++ b/multisend-ui/__tests__/checksums/ResultDisplay.test.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ResultDisplay from '@/components/checksums/ResultDisplay';
 import { CalculationResult } from '@/types/checksums';
+import { decodeMultiSendTransactions, tryDecodeFunctionData } from '@/utils/decoder';
+
+// Mock the decoder functions
+jest.mock('@/utils/decoder', () => ({
+  decodeMultiSendTransactions: jest.fn(),
+  tryDecodeFunctionData: jest.fn(),
+}));
 
 // Mock clipboard API
 Object.assign(navigator, {
@@ -15,6 +22,10 @@ Object.assign(navigator, {
 window.alert = jest.fn();
 
 describe('ResultDisplay', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   const mockResult: CalculationResult = {
     network: {
       name: 'Ethereum Mainnet',
@@ -133,11 +144,197 @@ describe('ResultDisplay', () => {
         },
       },
     };
-    
+
     render(<ResultDisplay result={resultWithParams} />);
-    
+
     // Check if parameters are rendered
     expect(screen.getByText(/Parameters/i)).toBeInTheDocument();
     expect(screen.getByText(/transfer/i)).toBeInTheDocument();
+  });
+
+  describe('multiSend transaction decoding', () => {
+    const multiSendResult: CalculationResult = {
+      network: {
+        name: 'Optimism',
+        chain_id: '10',
+      },
+      transaction: {
+        multisig_address: '0x398A2749487B2a91f2f543C01F7afD19AEE4b6b0',
+        to: '0x40A2aCCbd92BCA938b02010E17A5b8929b49130D',
+        value: '0',
+        data: '0x8d80ff0a0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000039600398a2749487b2a91f2f543c01f7afd19aee4b6b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000440d582f13000000000000000000000000e70a44002f53e5093e6b87eb934032d0e8aa83f5000000000000000000000000000000000000000000000000000000000000000200398a2749487b2a91f2f543c01f7afd19aee4b6b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000440d582f13000000000000000000000000f292526e0cdb4ab6a6f3616ee3a0a1b4e8c94fd6000000000000000000000000000000000000000000000000000000000000000300398a2749487b2a91f2f543c01f7afd19aee4b6b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000440d582f13000000000000000000000000d6b4e054c9a2fc21f8b94764df3a7f4cedaa6f3c000000000000000000000000000000000000000000000000000000000000000400398a2749487b2a91f2f543c01f7afd19aee4b6b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000440d582f13000000000000000000000000a9a6c7986f8e785f8c8067f24c536917a89e04f9000000000000000000000000000000000000000000000000000000000000000500398a2749487b2a91f2f543c01f7afd19aee4b6b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000440d582f1300000000000000000000000018b8767ef78caf3c72664ce72d8fb5273fe88a8e000000000000000000000000000000000000000000000000000000000000000500398a2749487b2a91f2f543c01f7afd19aee4b6b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000440d582f1300000000000000000000000093acad1d0c037bfb0302b0394fdc70a04bc40869000000000000000000000000000000000000000000000000000000000000000500000000000000000000',
+        encoded_message: '0xabcdef',
+        data_decoded: {
+          method: 'multiSend(bytes)',
+          signature: 'multiSend(bytes)',
+          source: 'manual',
+          parameters: [
+            {
+              name: 'transactions',
+              value: '00398a2749487b2a91f2f543c01f7afd19aee4b6b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000440d582f13000000000000000000000000e70a44002f53e5093e6b87eb934032d0e8aa83f5000000000000000000000000000000000000000000000000000000000000000200398a2749487b2a91f2f543c01f7afd19aee4b6b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000440d582f13000000000000000000000000f292526e0cdb4ab6a6f3616ee3a0a1b4e8c94fd6000000000000000000000000000000000000000000000000000000000000000300398a2749487b2a91f2f543c01f7afd19aee4b6b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000440d582f13000000000000000000000000d6b4e054c9a2fc21f8b94764df3a7f4cedaa6f3c000000000000000000000000000000000000000000000000000000000000000400398a2749487b2a91f2f543c01f7afd19aee4b6b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000440d582f13000000000000000000000000a9a6c7986f8e785f8c8067f24c536917a89e04f9000000000000000000000000000000000000000000000000000000000000000500398a2749487b2a91f2f543c01f7afd19aee4b6b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000440d582f1300000000000000000000000018b8767ef78caf3c72664ce72d8fb5273fe88a8e000000000000000000000000000000000000000000000000000000000000000500398a2749487b2a91f2f543c01f7afd19aee4b6b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000440d582f1300000000000000000000000093acad1d0c037bfb0302b0394fdc70a04bc408690000000000000000000000000000000000000000000000000000000000000005',
+              type: undefined
+            },
+            {
+              name: 'decodedTransactionsCount',
+              value: '6',
+              type: undefined
+            }
+          ]
+        }
+      },
+      hashes: {
+        domain_hash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+        message_hash: '0x2222222222222222222222222222222222222222222222222222222222222222',
+        safe_transaction_hash: '0x3333333333333333333333333333333333333333333333333333333333333333',
+      },
+    };
+
+    it('decodes and displays nested multiSend transactions', async () => {
+      // Mock the decoder to return nested transactions
+      const mockNestedTransactions = [
+        {
+          operation: 0,
+          to: '0x398a2749487b2a91f2f543c01f7afd19aee4b6b0',
+          value: '0',
+          dataLength: 68,
+          data: '0x0d582f13000000000000000000000000e70a44002f53e5093e6b87eb934032d0e8aa83f50000000000000000000000000000000000000000000000000000000000000002'
+        },
+        {
+          operation: 0,
+          to: '0x398a2749487b2a91f2f543c01f7afd19aee4b6b0',
+          value: '0',
+          dataLength: 68,
+          data: '0x0d582f13000000000000000000000000f292526e0cdb4ab6a6f3616ee3a0a1b4e8c94fd60000000000000000000000000000000000000000000000000000000000000003'
+        }
+      ];
+
+      (decodeMultiSendTransactions as jest.Mock).mockReturnValue(mockNestedTransactions);
+      (tryDecodeFunctionData as jest.Mock).mockImplementation((data: string) => {
+        if (data.startsWith('0x0d582f13')) {
+          return Promise.resolve({
+            name: 'removeOwner',
+            params: {
+              prevOwner: '0x0000000000000000000000000000000000000001',
+              owner: data.slice(34, 74),
+              _threshold: '2'
+            }
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      render(<ResultDisplay result={multiSendResult} />);
+
+      // Wait for async decoding to complete
+      await waitFor(() => {
+        expect(screen.getByText(/Nested Transactions \(2\)/i)).toBeInTheDocument();
+      });
+
+      // Check that nested transactions are displayed
+      expect(screen.getByText('Transaction #1')).toBeInTheDocument();
+      expect(screen.getByText('Transaction #2')).toBeInTheDocument();
+
+      // Check operation types
+      const operationTexts = screen.getAllByText(/Operation:/);
+      expect(operationTexts).toHaveLength(2);
+
+      // Check that 'Call' appears for both transactions
+      // The text might be part of "Operation: Call"
+      const callTexts = screen.getAllByText((content, element) => {
+        return element?.textContent === 'Operation: Call';
+      });
+      expect(callTexts).toHaveLength(2);
+
+      // Check that decoded function names are displayed
+      await waitFor(() => {
+        const removeOwnerTexts = screen.getAllByText(/removeOwner/);
+        expect(removeOwnerTexts).toHaveLength(2);
+      });
+
+      // Verify decodeMultiSendTransactions was called with the correct data
+      expect(decodeMultiSendTransactions).toHaveBeenCalledWith(
+        '0x' + multiSendResult.transaction!.data_decoded!.parameters![0].value
+      );
+    });
+
+    it('handles multiSend decoding errors gracefully', async () => {
+      // Mock decoder to throw an error
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      (decodeMultiSendTransactions as jest.Mock).mockImplementation(() => {
+        throw new Error('Failed to decode transactions');
+      });
+
+      render(<ResultDisplay result={multiSendResult} />);
+
+      // Should still render the basic multiSend info (appears in multiple places)
+      const multiSendTexts = screen.getAllByText(/multiSend\(bytes\)/);
+      expect(multiSendTexts.length).toBeGreaterThan(0);
+
+      // But should not show nested transactions
+      expect(screen.queryByText(/Nested Transactions/)).not.toBeInTheDocument();
+
+      // The error should be logged
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to decode nested multiSend transactions:',
+        expect.any(Error)
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('does not attempt to decode non-multiSend transactions', () => {
+      const nonMultiSendResult: CalculationResult = {
+        ...mockResult,
+        transaction: {
+          ...mockResult.transaction!,
+          data_decoded: {
+            method: 'transfer(address,uint256)',
+            parameters: [
+              { name: 'to', type: 'address', value: '0xabcdef' },
+              { name: 'value', type: 'uint256', value: '1000000000000000000' },
+            ],
+          },
+        },
+      };
+
+      render(<ResultDisplay result={nonMultiSendResult} />);
+
+      // Should show parameters normally
+      expect(screen.getByText(/Parameters/i)).toBeInTheDocument();
+
+      // Should not attempt to decode multiSend
+      expect(decodeMultiSendTransactions).not.toHaveBeenCalled();
+
+      // Should not show nested transactions
+      expect(screen.queryByText(/Nested Transactions/)).not.toBeInTheDocument();
+    });
+
+    it('displays all 6 nested transactions from the real example', async () => {
+      // Create 6 mock transactions matching the real data
+      const sixTransactions = Array.from({ length: 6 }, (_, i) => ({
+        operation: 0,
+        to: '0x398a2749487b2a91f2f543c01f7afd19aee4b6b0',
+        value: '0',
+        dataLength: 68,
+        data: `0x0d582f13${i.toString().padStart(64, '0')}${(i + 2).toString().padStart(64, '0')}`
+      }));
+
+      (decodeMultiSendTransactions as jest.Mock).mockReturnValue(sixTransactions);
+      (tryDecodeFunctionData as jest.Mock).mockResolvedValue({
+        name: 'removeOwner',
+        params: { prevOwner: '0x0001', owner: '0x0002', _threshold: '2' }
+      });
+
+      render(<ResultDisplay result={multiSendResult} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Nested Transactions \(6\)/i)).toBeInTheDocument();
+      });
+
+      // Check all 6 transactions are displayed
+      for (let i = 1; i <= 6; i++) {
+        expect(screen.getByText(`Transaction #${i}`)).toBeInTheDocument();
+      }
+    });
   });
 }); 

--- a/multisend-ui/components/checksums/ResultDisplay.tsx
+++ b/multisend-ui/components/checksums/ResultDisplay.tsx
@@ -42,20 +42,36 @@ export default function ResultDisplay({ result }: ResultDisplayProps) {
 
   // Decode function data for each nested transaction
   React.useEffect(() => {
-    if (nestedTransactions && nestedTransactions.length > 0) {
-      Promise.all(
-        nestedTransactions.map(tx =>
-          tx.data && tx.data !== '0x' ? tryDecodeFunctionData(tx.data) : null
-        )
-      ).then(decoded => {
-        setDecodedFunctions(decoded);
-      }).catch(error => {
-        console.error('Failed to decode nested transaction functions:', error);
-      });
-    } else {
-      // Clear decoded functions when no nested transactions
-      setDecodedFunctions([]);
-    }
+    const abortController = new AbortController();
+
+    const decodeTransactions = async () => {
+      if (nestedTransactions && nestedTransactions.length > 0) {
+        try {
+          const decoded = await Promise.all(
+            nestedTransactions.map(tx =>
+              tx.data && tx.data !== '0x' ? tryDecodeFunctionData(tx.data) : null
+            )
+          );
+
+          if (!abortController.signal.aborted) {
+            setDecodedFunctions(decoded);
+          }
+        } catch (error) {
+          if (!abortController.signal.aborted) {
+            console.error('Failed to decode nested transaction functions:', error);
+          }
+        }
+      } else {
+        // Clear decoded functions when no nested transactions
+        setDecodedFunctions([]);
+      }
+    };
+
+    decodeTransactions();
+
+    return () => {
+      abortController.abort();
+    };
   }, [nestedTransactions]);
 
   return (
@@ -113,7 +129,14 @@ export default function ResultDisplay({ result }: ResultDisplayProps) {
                     </div>
                   )}
                   {/* Show nested transactions for multiSend instead of raw parameters */}
-                  {nestedTransactions && nestedTransactions.length > 0 ? (
+                  {(() => {
+                    const hasNestedTransactions = nestedTransactions && nestedTransactions.length > 0;
+                    const shouldShowParameters = decodedData.parameters &&
+                                                decodedData.parameters.length > 0 &&
+                                                decodedData.method !== 'multiSend(bytes)';
+
+                    if (hasNestedTransactions) {
+                      return (
                     <div className="mt-2">
                       <div className="text-gray-500">Nested Transactions ({nestedTransactions.length}):</div>
                       <div className="mt-2 space-y-2 max-h-96 overflow-y-auto">
@@ -152,14 +175,22 @@ export default function ResultDisplay({ result }: ResultDisplayProps) {
                         })}
                       </div>
                     </div>
-                  ) : decodedData.parameters && decodedData.parameters.length > 0 && decodedData.method !== 'multiSend(bytes)' && (
-                    <div className="mt-2">
-                      <div className="text-gray-500">Parameters:</div>
-                      <pre className="bg-gray-100 p-2 rounded text-xs overflow-x-auto">
-                        {JSON.stringify(decodedData.parameters, null, 2)}
-                      </pre>
-                    </div>
-                  )}
+                      );
+                    }
+
+                    if (shouldShowParameters) {
+                      return (
+                        <div className="mt-2">
+                          <div className="text-gray-500">Parameters:</div>
+                          <pre className="bg-gray-100 p-2 rounded text-xs overflow-x-auto">
+                            {JSON.stringify(decodedData.parameters, null, 2)}
+                          </pre>
+                        </div>
+                      );
+                    }
+
+                    return null;
+                  })()}
                 </div>
               </div>
             )}

--- a/multisend-ui/components/checksums/ResultDisplay.tsx
+++ b/multisend-ui/components/checksums/ResultDisplay.tsx
@@ -2,14 +2,14 @@
 
 import React, { useMemo } from 'react';
 import { CalculationResult } from '@/types/checksums';
-import { decodeMultiSendTransactions, tryDecodeFunctionData } from '@/utils/decoder';
+import { decodeMultiSendTransactions, tryDecodeFunctionData, DecodedFunctionData } from '@/utils/decoder';
 
 interface ResultDisplayProps {
   result: CalculationResult;
 }
 
 export default function ResultDisplay({ result }: ResultDisplayProps) {
-  const [decodedFunctions, setDecodedFunctions] = React.useState<Array<any>>([]);
+  const [decodedFunctions, setDecodedFunctions] = React.useState<Array<DecodedFunctionData | null>>([]);
   if (result.error) {
     return (
       <div className="bg-red-50 text-red-700 p-4 rounded-md">
@@ -52,6 +52,9 @@ export default function ResultDisplay({ result }: ResultDisplayProps) {
       }).catch(error => {
         console.error('Failed to decode nested transaction functions:', error);
       });
+    } else {
+      // Clear decoded functions when no nested transactions
+      setDecodedFunctions([]);
     }
   }, [nestedTransactions]);
 

--- a/multisend-ui/components/checksums/ResultDisplay.tsx
+++ b/multisend-ui/components/checksums/ResultDisplay.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { CalculationResult } from '@/types/checksums';
+import { decodeMultiSendTransactions, tryDecodeFunctionData } from '@/utils/decoder';
 
 interface ResultDisplayProps {
   result: CalculationResult;
 }
 
 export default function ResultDisplay({ result }: ResultDisplayProps) {
+  const [decodedFunctions, setDecodedFunctions] = React.useState<Array<any>>([]);
   if (result.error) {
     return (
       <div className="bg-red-50 text-red-700 p-4 rounded-md">
@@ -18,6 +20,40 @@ export default function ResultDisplay({ result }: ResultDisplayProps) {
   }
 
   const decodedData = result.transaction?.data_decoded;
+
+  // Decode nested multiSend transactions if present
+  const nestedTransactions = useMemo(() => {
+    if (
+      decodedData?.method === 'multiSend(bytes)' &&
+      decodedData?.parameters?.find(p => p.name === 'transactions')
+    ) {
+      try {
+        const transactionsParam = decodedData.parameters.find(p => p.name === 'transactions');
+        if (transactionsParam) {
+          const innerData = '0x' + transactionsParam.value;
+          return decodeMultiSendTransactions(innerData);
+        }
+      } catch (error) {
+        console.error('Failed to decode nested multiSend transactions:', error);
+      }
+    }
+    return null;
+  }, [decodedData]);
+
+  // Decode function data for each nested transaction
+  React.useEffect(() => {
+    if (nestedTransactions && nestedTransactions.length > 0) {
+      Promise.all(
+        nestedTransactions.map(tx =>
+          tx.data && tx.data !== '0x' ? tryDecodeFunctionData(tx.data) : null
+        )
+      ).then(decoded => {
+        setDecodedFunctions(decoded);
+      }).catch(error => {
+        console.error('Failed to decode nested transaction functions:', error);
+      });
+    }
+  }, [nestedTransactions]);
 
   return (
     <div className="space-y-6">
@@ -73,7 +109,47 @@ export default function ResultDisplay({ result }: ResultDisplayProps) {
                       Other matches: {decodedData.candidates.filter(candidate => candidate !== decodedData.method).join(', ')}
                     </div>
                   )}
-                  {decodedData.parameters && decodedData.parameters.length > 0 && (
+                  {/* Show nested transactions for multiSend instead of raw parameters */}
+                  {nestedTransactions && nestedTransactions.length > 0 ? (
+                    <div className="mt-2">
+                      <div className="text-gray-500">Nested Transactions ({nestedTransactions.length}):</div>
+                      <div className="mt-2 space-y-2 max-h-96 overflow-y-auto">
+                        {nestedTransactions.map((tx, index) => {
+                          const decodedFunc = decodedFunctions[index];
+                          return (
+                            <div key={index} className="bg-gray-100 p-2 rounded text-xs">
+                              <div className="font-semibold">Transaction #{index + 1}</div>
+                              <div>Operation: {tx.operation === 0 ? 'Call' : 'DelegateCall'}</div>
+                              <div>To: {tx.to}</div>
+                              <div>Value: {tx.value}</div>
+                              {decodedFunc ? (
+                                <div className="mt-1">
+                                  <div className="text-blue-600">Function: {decodedFunc.name}</div>
+                                  {decodedFunc.params && Object.keys(decodedFunc.params).length > 0 && (
+                                    <div className="ml-2 mt-1">
+                                      {Object.entries(decodedFunc.params).map(([key, value]) => (
+                                        <div key={key} className="text-gray-600">
+                                          {key}: {String(value).length > 50
+                                            ? `${String(value).slice(0, 25)}...${String(value).slice(-10)}`
+                                            : String(value)}
+                                        </div>
+                                      ))}
+                                    </div>
+                                  )}
+                                </div>
+                              ) : (
+                                <div>
+                                  Data: {tx.data.length > 66
+                                    ? `${tx.data.slice(0, 30)}...${tx.data.slice(-20)}`
+                                    : tx.data}
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ) : decodedData.parameters && decodedData.parameters.length > 0 && decodedData.method !== 'multiSend(bytes)' && (
                     <div className="mt-2">
                       <div className="text-gray-500">Parameters:</div>
                       <pre className="bg-gray-100 p-2 rounded text-xs overflow-x-auto">


### PR DESCRIPTION
## Summary
  - Enhanced ResultDisplay component to properly decode and display nested multiSend
  transactions
  - Added comprehensive test coverage for multiSend decoding functionality
  - Fixed issue where multiSend transactions only showed raw hex data instead of decoded nested
   transactions

  ## Changes
  - Modified components/checksums/ResultDisplay.tsx to decode and display nested transactions
  - Added tests to verify multiSend decoding functionality

  ## Test plan
  - [x] All existing tests pass
  - [x] New tests added for multiSend decoding functionality
  - [x] Manually tested with the provided multiSend example

  🤖 Generated with [Claude Code](https://claude.ai/code)